### PR TITLE
1.时间不对会导致身份证认证器失效，在系统配置里面添加时间的配置，管理员直接可以在页面配置调整系统时间

### DIFF
--- a/server/www/teleport/static/js/tp-utils.js
+++ b/server/www/teleport/static/js/tp-utils.js
@@ -387,3 +387,15 @@ function tp_check_strong_password(p) {
 
     return !!((s & 1) && (s & 2) && (s & 4));
 }
+
+//检查日期合法性
+function check_date_valid(date) {
+    var reg = /^(\d{1,4})(-|\/)(\d{1,2})\2(\d{1,2}) (\d{1,2}):(\d{1,2}):(\d{1,2})$/;
+    var r = date.match(reg);
+    if(r == null) {
+        $tp.notify_error("输入格式不正确！" + date);
+        return false;
+    } else {
+        return true;
+    }
+}

--- a/server/www/teleport/view/system/config.mako
+++ b/server/www/teleport/view/system/config.mako
@@ -22,6 +22,7 @@
             <li><a href="#tab-session" data-toggle="tab">连接控制</a></li>
             <li><a href="#tab-smtp" data-toggle="tab">邮件系统</a></li>
             <li><a href="#tab-storage" data-toggle="tab">存储</a></li>
+            <li><a href="#tab-systime" data-toggle="tab">时间</a></li>
             ##             <li><a href="#tab-backup" data-toggle="tab">备份</a></li>
         </ul>
 
@@ -359,6 +360,24 @@
                 <button id="btn-save-storage-config" class="btn btn-sm btn-primary"><i class="fa fa-check-circle fa-fw"></i> 保存存储设置</button>
                 ##                 <button id="btn-clear-storage" class="btn btn-sm btn-danger"><i class="fa fa-edit fa-fw"></i> 立即清理</button>
             </div>
+
+            <!-- panel for system time config -->
+            <div class="tab-pane" id="tab-systime">
+                <div class="alert alert-warning">
+                    注意：当系统时间偏离过多时，动态身份认证器将失效，可以在这里设置系统时间。请谨慎设置！
+                </div>
+                <div class="alert alert-info">
+                    当前服务器系统时间：<span id="system-time">-</span>
+                </div>
+
+                <div>
+                    <input type="date" id="system-data-set" />
+                    <input type="time" id="system-time-set" step="1" />
+                    <input type="button" id="btn-system-time-save"  value="保存系统时间" />
+                </div>
+                <hr/>
+            </div>
+
 
             <!-- panel for backup config -->
             ##             <div class="tab-pane" id="tab-backup">

--- a/server/www/teleport/webroot/app/controller/__init__.py
+++ b/server/www/teleport/webroot/app/controller/__init__.py
@@ -255,6 +255,8 @@ controllers = [
     #
     #  - [json] 获取服务器时间
     (r'/system/get-time', system.DoGetTimeHandler),
+    #  - [json] 设置服务器时间
+    (r'/system/set-time', system.DoSetTimeHandler),
     #  - [json] 重建授权映射
     (r'/system/rebuild-ops-auz-map', system.DoRebuildOpsAuzMapHandler),
     (r'/system/rebuild-audit-auz-map', system.DoRebuildAuditAuzMapHandler),

--- a/server/www/teleport/webroot/app/controller/user.py
+++ b/server/www/teleport/webroot/app/controller/user.py
@@ -608,9 +608,12 @@ class DoUpdateUserHandler(TPBaseJsonHandler):
                         subject='用户密码函'
                     )
                     if err != TPE_OK:
-                        return self.write_json(TPE_OK, '用户账号创建成功，但发送密码函失败：{}'.format(msg))
+                        return self.write_json(TPE_OK, '<font color="#e33b3b">用户账号创建成功，但发送密码函失败：{}</font>'.format(msg))
                     else:
                         return self.write_json(TPE_OK)
+                #在没配置邮箱得情况下给出错误提示
+                else:
+                    return self.write_json(TPE_OK, '<font color="#e33b3b">用户账号创建成功，但发送密码函失败。请检查邮件配置。</font>')
             else:
                 return self.write_json(err)
         else:


### PR DESCRIPTION
2.邮箱没有配置的时候创建账号，实际成功了但是没发邮件，完全红色的提示容易有误解-->改为绿底红色显示。